### PR TITLE
Fix linea issue and coverage command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ forge test --force
 Generate coverage report:
 
 ```bash
-forge coverage --force
+forge clean && forge build && forge coverage
 ```
 
 ## Deployment

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ build_info = true
 extra_output = ["storageLayout"]
 out = "out"
 solc = "0.8.22"
+evm_version = "paris"
 fs_permissions = [{ access = "read", path = "out" }, { access = "read", path = "test/fixtures" }]
 
 [dependencies]


### PR DESCRIPTION
- Fix issue with Linea. Linea does not have the PUSH0 opcode (see details below). 
      option 1: downgrade to 0.8.19
      option 2: see if via-ir could do something
      option 3: => Forcing Paris fork <== MUCH SIMPLER!!
- Fix command in readme for coverage. Unrelated to Linea, but took the opportunity of this PR to fix the README on that


https://docs.linea.build/get-started/build/ethereum-differences:
PUSH0 was introduced in the Ethereum Mainnet Shanghai upgrade and became available in Solidity compiler version 0.8.20, which came after the London release. However, Linea currently supports compiled code targeting the London release of the Ethereum Mainnet. Use the EVM Version of London when compiling to align with Linea's capabilities.