### PR TITLE
[Ready for merge] Prevent possible upgrade if primo-dep

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -51,6 +51,11 @@ contract Deploy is Script, IDeployOptions {
             proxyAddress = Upgrades.deployUUPSProxy(
                 "KeyringCore.sol", abi.encodeCall(KeyringCore.initialize, signatureCheckerAddress)
             );
+            KeyringCore keyringCore = KeyringCore(proxyAddress);
+            if (keyringCore.mustBeReInitialized()) {
+                console.log("Bump version to most recent");
+                keyringCore.reinitialize(signatureCheckerAddress);
+            }
             vm.stopBroadcast();
         } else {
             // Upgrade the proxy

--- a/src/KeyringCore.sol
+++ b/src/KeyringCore.sol
@@ -8,6 +8,10 @@ import "./interfaces/IKeyringCore.sol";
 import "./interfaces/ISignatureChecker.sol";
 
 contract KeyringCore is IKeyringCore, Initializable, OwnableUpgradeable, UUPSUpgradeable {
+    /// @dev Current implementation version
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    uint64 private immutable CURRENT_VERSION;
+
     /// @dev Address of the admin.
     address internal _admin;
 
@@ -22,6 +26,7 @@ contract KeyringCore is IKeyringCore, Initializable, OwnableUpgradeable, UUPSUpg
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
+        CURRENT_VERSION = 4;
         _disableInitializers();
     }
 
@@ -44,9 +49,23 @@ contract KeyringCore is IKeyringCore, Initializable, OwnableUpgradeable, UUPSUpg
      * @param _signatureChecker The address of the signature checker.
      * @dev This function is only callable by the owner.
      */
-    function reinitialize(address _signatureChecker) public onlyOwner reinitializer(4) {
+    function reinitialize(address _signatureChecker) public onlyOwner reinitializer(CURRENT_VERSION) {
         setSignatureChecker(_signatureChecker);
     }
+
+    /**
+     * @notice Returns the initialized version of the contract.
+     * @return The initialized version of the contract.
+     */
+    function mustBeReInitialized() public view returns (bool) {
+        return _getInitializedVersion() < CURRENT_VERSION;
+    }
+
+    /**
+     * @notice Authorizes the upgrade of the contract.
+     * @dev This function is only callable by the owner.
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     /**
      * @notice Sets the signature checker.
@@ -59,12 +78,6 @@ contract KeyringCore is IKeyringCore, Initializable, OwnableUpgradeable, UUPSUpg
         }
         signatureChecker = ISignatureChecker(_signatureChecker);
     }
-
-    /**
-     * @notice Authorizes the upgrade of the contract.
-     * @dev This function is only callable by the owner.
-     */
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     /**
      * @inheritdoc IKeyringCore

--- a/test/script/Deploy.t.sol
+++ b/test/script/Deploy.t.sol
@@ -120,6 +120,17 @@ contract DeployTest is Test, IDeployOptions {
         assertEq(upgradedProxyAddress, proxyAddress, "Proxy address should remain the same");
     }
 
+    function test_RevertOnUpgradeWithTheSameVersion() public {
+        setEnv("PRIVATE_KEY", deployerPrivateKey);
+        setEnv("SIGNATURE_CHECKER_NAME", "AlwaysValidSignatureChecker");
+        address proxyAddress = address(run());
+        assertTrue(address(proxyAddress) != address(0));
+
+        setEnv("PROXY_ADDRESS", vm.toString(proxyAddress));
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        run();
+    }
+
     function test_RevertOnUpgradeWithInvalidOwner() public {
         setEnv("PRIVATE_KEY", deployerPrivateKey);
         setEnv("SIGNATURE_CHECKER_NAME", "AlwaysValidSignatureChecker");


### PR DESCRIPTION
## Context
The deployment of a brand new proxy will set version 1 to the contract, which is below the current version of the codebase

## Done
- [x] Have the deploy script reinit the contrat after initialization to force bump the contract to the current version
- [x] Add tests