### PR TITLE
[Ready for merge] Align artefacts naming

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -91,6 +91,8 @@ for SIGNATURE_CHECKER_NAME in $SIGNATURE_CHECKERS_NAMES; do
     echo "Proxy address for the signature checker $SIGNATURE_CHECKER_NAME: $(cat "$OUT_FOLDER/KeyringCoreProxy.address")"
     NEW_NAME=$(echo "$SIGNATURE_CHECKER_NAME" | sed 's/SignatureChecker//')
     mv "$OUT_FOLDER/KeyringCoreProxy.address" "$OUT_FOLDER/KeyringCore$NEW_NAME.address"
+    mkdir -p "$OUT_FOLDER/KeyringCore$NEW_NAME.sol"
+    ln -s "$OUT_FOLDER/KeyringCore.sol/KeyringCore.json" "$OUT_FOLDER/KeyringCore$NEW_NAME.sol/KeyringCore$NEW_NAME.json"
 done
 
 


### PR DESCRIPTION
## Context
(see [KEY-2867](https://linear.app/keyring-network/issue/KEY-2867/issues-for-docker-deployment-of-testnet-smart-contracts#comment-8f83a634))
For backend tests, the `KeyringCore{signatureType}.address` file should have its corresponding `KeyringCore{signatureType}.sol` folder, containing a `KeyringCore{signatureType}.json` file 

## Done
- [x] For each "signatureType" smart contract generated, have a folder created and a the abi json file symlinked to the KeyringCore.json abi