### PR TITLE
[READY FOR MERGE] Fix register key to use validFrom and not chainId

### DIFF
--- a/src/interfaces/IKeyringCore.sol
+++ b/src/interfaces/IKeyringCore.sol
@@ -23,12 +23,12 @@ interface IKeyringCore {
      * @notice Represents a key entry.
      * @dev Contains validity status and the validity period of the key.
      * @param isValid Indicates if the key is valid.
-     * @param chainId The chainId for which a credential is valid.
+     * @param validFrom The start time of the key's validity.
      * @param validTo The end time of the key's validity.
      */
     struct KeyEntry {
         bool isValid;
-        uint64 chainId;
+        uint64 validFrom;
         uint64 validTo;
     }
 
@@ -70,10 +70,10 @@ interface IKeyringCore {
 
     /// @notice Event emitted when a key is registered.
     /// @param keyHash The hash of the key.
-    /// @param chainId The chainId for which the key is valid.
+    /// @param validFrom The start time of the key's validity.
     /// @param validTo The end time of the key's validity.
     /// @param publicKey The public key.
-    event KeyRegistered(bytes32 indexed keyHash, uint256 indexed chainId, uint256 indexed validTo, bytes publicKey);
+    event KeyRegistered(bytes32 indexed keyHash, uint256 indexed validFrom, uint256 indexed validTo, bytes publicKey);
 
     /// @notice Event emitted when a key is revoked.
     /// @param keyHash The hash of the key.

--- a/test/src/KeyringCore.t.sol
+++ b/test/src/KeyringCore.t.sol
@@ -149,7 +149,7 @@ contract KeyringCoreTest is Test {
     function test_RegisterKeyAlreadyRegistered() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-            keyringCore.registerKey(validFrom, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         vm.expectRevert(abi.encodeWithSelector(IKeyringCore.ErrInvalidKeyRegistration.selector, "KAR"));
         keyringCore.registerKey(validFrom, validTo, testKey);
     }

--- a/test/src/KeyringCore.t.sol
+++ b/test/src/KeyringCore.t.sol
@@ -42,7 +42,9 @@ contract KeyringCoreTest is Test {
     }
 
     function test_RegisterAndRevokeKey() public {
-        keyringCore.registerKey(block.chainid, validTo, key);
+        uint256 validFrom = block.timestamp;
+        validTo = validFrom + 1 days;
+        keyringCore.registerKey(validFrom, validTo, key);
         bytes32 keyHash = keccak256(key);
         assertTrue(keyringCore.keyExists(keyHash));
 
@@ -71,13 +73,17 @@ contract KeyringCoreTest is Test {
     }
 
     function test_FailRegisterKeyFromNonAdmin() public {
+        uint256 validFrom = block.timestamp;
+        validTo = validFrom + 1 days;
         vm.prank(newAdmin);
         vm.expectRevert(abi.encodeWithSelector(IKeyringCore.ErrCallerNotAdmin.selector, newAdmin));
-        keyringCore.registerKey(block.chainid, validTo, key);
+        keyringCore.registerKey(validFrom, validTo, key);
     }
 
     function test_FailRevokeKeyFromNonAdmin() public {
-        keyringCore.registerKey(block.chainid, validTo, key);
+        uint256 validFrom = block.timestamp;
+        validTo = validFrom + 1 days;
+        keyringCore.registerKey(validFrom, validTo, key);
         bytes32 keyHash = keccak256(key);
 
         vm.prank(newAdmin);
@@ -128,7 +134,7 @@ contract KeyringCoreTest is Test {
     function test_RegisterKeyByAdmin() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         assertTrue(keyringCore.keyExists(testKeyHash));
     }
 
@@ -137,21 +143,21 @@ contract KeyringCoreTest is Test {
         validTo = validFrom + 1 days;
         vm.prank(newAdmin);
         vm.expectRevert(abi.encodeWithSelector(IKeyringCore.ErrCallerNotAdmin.selector, newAdmin));
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
     }
 
     function test_RegisterKeyAlreadyRegistered() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+            keyringCore.registerKey(validFrom, validTo, testKey);
         vm.expectRevert(abi.encodeWithSelector(IKeyringCore.ErrInvalidKeyRegistration.selector, "KAR"));
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
     }
 
     function test_RevokeKeyByAdmin() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         keyringCore.revokeKey(testKeyHash);
         assertFalse(keyringCore.keyExists(testKeyHash));
     }
@@ -159,7 +165,7 @@ contract KeyringCoreTest is Test {
     function test_RevokeKeyByNonAdmin() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         vm.prank(newAdmin);
         vm.expectRevert(abi.encodeWithSelector(IKeyringCore.ErrCallerNotAdmin.selector, newAdmin));
         keyringCore.revokeKey(testKeyHash);
@@ -198,7 +204,7 @@ contract KeyringCoreTest is Test {
     function test_CredentialCreationExpired() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 2 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
         vm.warp(block.timestamp + 1 days + 1 minutes);
@@ -211,7 +217,7 @@ contract KeyringCoreTest is Test {
     function test_CreateCredentialWithWrongChainId() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -223,7 +229,7 @@ contract KeyringCoreTest is Test {
     function test_CreateCredentialOkAndKo() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         // pass 1 - new credential
         uint256 validUntil = block.timestamp + 1 days;
@@ -245,7 +251,7 @@ contract KeyringCoreTest is Test {
     function test_CreateCredentialInsufficientPayment() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -256,7 +262,7 @@ contract KeyringCoreTest is Test {
     function test_CreateCredentialInvalidKey() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         vm.warp(block.timestamp + 2 days);
 
         uint256 validUntil = block.timestamp + 1 days;
@@ -268,7 +274,7 @@ contract KeyringCoreTest is Test {
     function test_CreateCredentialBlacklistedEntity() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         keyringCore.blacklistEntity(1, newAdmin);
 
         uint256 validUntil = block.timestamp + 1 days;
@@ -280,7 +286,7 @@ contract KeyringCoreTest is Test {
     function test_CreateCredentialExpirationInPast() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -293,7 +299,7 @@ contract KeyringCoreTest is Test {
     function test_CollectFeesByAdmin() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -325,7 +331,7 @@ contract KeyringCoreTest is Test {
     function test_KeyExists() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         assertTrue(keyringCore.keyExists(testKeyHash));
         keyringCore.revokeKey(testKeyHash);
         assertFalse(keyringCore.keyExists(testKeyHash));
@@ -334,16 +340,16 @@ contract KeyringCoreTest is Test {
     function test_KeyValidTo() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         assertEq(keyringCore.keyValidTo(testKeyHash), validTo);
     }
 
     function test_KeyDetails() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
         IKeyringCore.KeyEntry memory kd = keyringCore.keyDetails(testKeyHash);
-        assertEq(kd.chainId, block.chainid);
+        assertEq(kd.validFrom, validFrom);
         assertEq(kd.validTo, validTo);
         assertTrue(kd.isValid);
     }
@@ -358,7 +364,7 @@ contract KeyringCoreTest is Test {
     function test_EntityExp() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -369,7 +375,7 @@ contract KeyringCoreTest is Test {
     function test_EntityData() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -382,7 +388,7 @@ contract KeyringCoreTest is Test {
     function test_CheckCredential() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -393,7 +399,7 @@ contract KeyringCoreTest is Test {
     function test_CheckCredentialExpired() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 
@@ -406,7 +412,7 @@ contract KeyringCoreTest is Test {
     function test_CheckCredentialBlacklisted() public {
         uint256 validFrom = block.timestamp;
         validTo = validFrom + 1 days;
-        keyringCore.registerKey(block.chainid, validTo, testKey);
+        keyringCore.registerKey(validFrom, validTo, testKey);
 
         uint256 validUntil = block.timestamp + 1 days;
 

--- a/test/src/KeyringCoreE2EEIP191.t.sol
+++ b/test/src/KeyringCoreE2EEIP191.t.sol
@@ -25,7 +25,7 @@ contract KeyringCoreE2EEIP191Test is BaseDeployTest {
         setEnv("PRIVATE_KEY", deployerPrivateKey);
         keyringCore = run();
         vm.startPrank(keyringCore.admin());
-        keyringCore.registerKey(block.chainid, block.timestamp + 1000, key);
+        keyringCore.registerKey(block.timestamp, block.timestamp + 1000, key);
         vm.stopPrank();
         assertEq(keyringCore.getKeyHash(key), 0x8dd832049319556c1cd22ed66ae790d07fea25830a6151c2f0a9879b3ef61305);
     }
@@ -33,7 +33,7 @@ contract KeyringCoreE2EEIP191Test is BaseDeployTest {
     function test_createCredentialWithRegisteredKey() public {
         assertEq(keyringCore.checkCredential(tradingAddress, policyId), false);
         keyringCore.createCredential{value: cost}(
-            tradingAddress, policyId, uint256(block.chainid), validUntil, cost, key, signatureMsg, backdoor
+            tradingAddress, policyId, block.chainid, validUntil, cost, key, signatureMsg, backdoor
         );
         assertEq(keyringCore.checkCredential(tradingAddress, policyId), true);
     }
@@ -44,7 +44,7 @@ contract KeyringCoreE2EEIP191Test is BaseDeployTest {
             abi.encodeWithSelector(IKeyringCore.ErrInvalidCredential.selector, policyId, tradingAddress, "SIG")
         );
         keyringCore.createCredential{value: cost}(
-            tradingAddress, policyId, uint256(block.chainid), validUntil, cost, key, invalidSignatureMsg, backdoor
+            tradingAddress, policyId, block.chainid, validUntil, cost, key, invalidSignatureMsg, backdoor
         );
         assertEq(keyringCore.checkCredential(tradingAddress, policyId), false);
     }
@@ -58,7 +58,7 @@ contract KeyringCoreE2EEIP191Test is BaseDeployTest {
             abi.encodeWithSelector(IKeyringCore.ErrInvalidCredential.selector, policyId, tradingAddress, "BDK")
         );
         keyringCore.createCredential{value: cost}(
-            tradingAddress, policyId, uint256(block.chainid), validUntil, cost, key, signatureMsg, backdoor
+            tradingAddress, policyId, block.chainid, validUntil, cost, key, signatureMsg, backdoor
         );
     }
 }

--- a/test/src/KeyringCoreE2ERSA.t.sol
+++ b/test/src/KeyringCoreE2ERSA.t.sol
@@ -32,8 +32,8 @@ contract KeyringCoreE2ERSATest is BaseDeployTest {
         setEnv("PRIVATE_KEY", deployerPrivateKey);
         keyringCore = run();
         vm.startPrank(keyringCore.admin());
-        keyringCore.registerKey(block.chainid, block.timestamp + 1000, registeredKey1);
-        keyringCore.registerKey(block.chainid, block.timestamp + 1000, registeredKey2);
+        keyringCore.registerKey(block.timestamp, block.timestamp + 1000, registeredKey1);
+        keyringCore.registerKey(block.timestamp, block.timestamp + 1000, registeredKey2);
         vm.stopPrank();
         assertEq(
             keyringCore.getKeyHash(registeredKey1), 0xe52a7c12d4c85c83f074d657813427b6d9c7ac2fef28d112045580ce15154373


### PR DESCRIPTION
`registerKey` method must keep using `validFrom` and not `chainId`. 
- [x] Fix this