### PR TITLE
Upgrading base.Dockerfile to ubuntu 22.04

### DIFF
--- a/dockerfiles/smart-contracts.base.Dockerfile
+++ b/dockerfiles/smart-contracts.base.Dockerfile
@@ -3,7 +3,7 @@
 # The project directory is prepared and dependencies are initialized using Forge.
 
 # Use a lightweight base image
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Set the timezone to UTC non-interactively
 ENV TZ=Etc/UTC


### PR DESCRIPTION
Foundry tools installed via foundryup require newer GLIBC versions (2.32, 2.33, 2.34) than what's available in the Ubuntu 20.04 base image used in our Dockerfile.

We can either upgrade the OS version or find what version of foundry we want that is also compatible and then pin that.